### PR TITLE
Changed this tool to enroll subject from the existing subject table

### DIFF
--- a/test/lib/subject.js
+++ b/test/lib/subject.js
@@ -71,7 +71,8 @@ module.exports = function(client, config) {
     me.new.submit = function(done) {
         done = done || noop;
         return client
-            .moveToObject('#submit_new_subject')
+            .pause(1000)
+            .scroll('#submit_new_subject')
             .click('#submit_new_subject')
             .waitForPaginationComplete()
             .pause(100)
@@ -139,16 +140,21 @@ module.exports = function(client, config) {
             .call(done);
     };
 
-    me.enroll.prepExisting = function(ursi, done) {
-        if (!ursi) {
-            throw new Error('URSI to enroll must be provided');
+    me.new.handleSubjectMatchesExisting = function() {
+        client
+            .scroll(0, 0)
+            .setValue('.coins-datatable-wrapper input[type=search]', 'testaddressline1')
+            .click('//*[@id="datatable-container"]/tbody/tr[1]/td[8]/a')
+            .pause(500);
+
+        // Create/Re-use
+        if (Date.now() % 2 === 0) {
+            client.click("#page-container > div.boxBody > div > a:nth-child(2)");            
+        } else {
+            client.click("#page-container > div.boxBody > div > a:nth-child(5)");
         }
-        done = done || noop;
-        return client
-            .click('[name="ursi"]')
-            .setValue('input[name="ursi"]', ursi)
-            .selectByValue('[name="study_id"]', 3580)
-            .call(done);
+
+        client.click("input[type=button][value=Continue]");
     };
 
     me.enroll.submitExisting = function(done) {

--- a/test/subject-enroll.js
+++ b/test/subject-enroll.js
@@ -18,17 +18,40 @@ describe('subject enroll', function() {
         });
     });
 
-    describe('enroll existing subject', function() {
+    describe('add subject form', function() {
         it('should be accessible', function(done) {
             nav.micisMenu
-                .clickNested('Enroll an Existing Subject')
+                .clickNested('Enter a New Subject')
                 .call(done);
         });
 
-       it('should lookup an existing URSI (NITEST URSI M06158639 >> BIOMARKERS)', function(done) {
-            subject.enroll.prepExisting('M06158639');
-            subject.enroll.submitExisting(done);
+        it('should be fill-out-able', function(done) {
+            // fill form
+            subject.new.fillForm();
+
+            // Change study id
+            client.selectByValue('#study_id', 7640); // Smoking
+
+            client.call(done);
         });
+        
+        it('should be submittable', function(done) {
+            subject.new.submit(done);
+        });
+        
     });
+
+    describe('verify subject form', function() {        
+        it('should be submittable', function(done) {
+            subject.new.verify(done);
+        });        
+    });
+
+    describe('handle new subject matches form', function() {
+        it('should be enroll with existing subject', function(done) {
+            subject.new.handleSubjectMatchesExisting(done);
+        });        
+    });
+    
 
 });


### PR DESCRIPTION
# Problem
The Enroll Existing Subject tool has been removed. 

# Solution
After talking to @bmillermrn, this test is actually meant to test enrolling from the match list when adding a subject. 