### PR TITLE
updated dx statistics count

### DIFF
--- a/test/dx-new-request.js
+++ b/test/dx-new-request.js
@@ -137,7 +137,7 @@ describe('Test data exchange functionality for a new request', function dxNewReq
       .pause(2000)
       .getText(statistics)
       .then((response) => {
-        response.should.be.eql(['3748', '2396', '3', '1386']);
+        response.should.be.eql(['3748', '1730', '3', '1385']);
       })
       .call(done);
   });
@@ -151,7 +151,7 @@ describe('Test data exchange functionality for a new request', function dxNewReq
       .pause(2000)
       .getText(statistics)
       .then((response) => {
-        response.should.be.eql(['1495', '1284', '2', '274']);
+        response.should.be.eql(['1495', '618', '2', '273']);
       })
       .call(done);
   });


### PR DESCRIPTION
# Problem
Some of the underlying DX data has changed which is causing the expected getStatistics counts for some tests to fail.

# Solution
Update the test to match the new counts. (Until we get a test DB setup to avoid these issues)